### PR TITLE
#73 ContentHeader 컴포넌트 

### DIFF
--- a/components/LinkBar.tsx
+++ b/components/LinkBar.tsx
@@ -16,7 +16,7 @@ export default function LinkBar({ link, onClick }: LinkBarProps) {
       className="flex cursor-pointer items-center gap-[5px] rounded-custom bg-green-100 px-[10px] py-[3px] mo:py-1"
     >
       <img
-        src="icon/icon-link.svg"
+        src="/icon/icon-link.svg"
         alt="링크 아이콘"
         className="h-5 w-5 mo:h-4 mo:w-4"
       />

--- a/pages/wiki/components/ContentHeader.tsx
+++ b/pages/wiki/components/ContentHeader.tsx
@@ -24,7 +24,7 @@ export default function ContentHeader({
 }: ContentHeaderProps) {
   return (
     <div>
-      <div className="mb-[10px] mb-[32px] flex items-center justify-between text-48sb text-gray-500 mo:mb-[24px] mo:text-32sb">
+      <div className="mb-[32px] flex items-center justify-between text-48sb text-gray-500 mo:mb-[24px] mo:text-32sb">
         {isEditing ? (
           <InputField
             type="text"

--- a/pages/wiki/components/ContentHeader.tsx
+++ b/pages/wiki/components/ContentHeader.tsx
@@ -1,0 +1,41 @@
+import InputField from '@/components/Input';
+import LinkBar from '@/components/LinkBar';
+
+interface ContentHeaderProps {
+  name: string;
+  link: string;
+  onNameChange: (value: string) => void;
+  isEditing: boolean;
+}
+
+/**
+ * Content 컴포넌트의 헤더에 해당하는 컴포넌트
+ * @param name 위키문서의 이름
+ * @param link 위키문서의 링크
+ * @param onNameChange 이름이 변경될 때 호출되는 콜백 함수
+ * @param isEditing 편집 모드인지 여부
+ */
+
+export default function ContentHeader({
+  name,
+  link,
+  onNameChange,
+  isEditing,
+}: ContentHeaderProps) {
+  return (
+    <div>
+      <div className="mb-[10px] mb-[32px] flex items-center justify-between text-48sb text-gray-500 mo:mb-[24px] mo:text-32sb">
+        {isEditing ? (
+          <InputField
+            type="text"
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+          />
+        ) : (
+          <span>{name}</span>
+        )}
+      </div>
+      {!isEditing && <LinkBar link={link} />}
+    </div>
+  );
+}


### PR DESCRIPTION
## 이슈 번호

close #73 

## 변경 사항 요약

- 위키 페이지의 이름과 링크를 포함하는 컴포넌트입니다.

## Doc

_`컴포넌트 인 경우 props를 입력해주세요`_

| **Props** | **Type** | **Description** |
| --------- | -------- | --------------- |
| ` name`      | `string  `     | 위키문서의 이름       |
| `link `      | ` string `     | 위키문서의 링크       |
| `onNameChange `      | ` function `     | 이름이 변경될 때 호출되는 콜백 함수    |
| `isEditing `      | ` boolean `     | 편집 모드인지 여부  |

## 테스트 결과

![image](https://github.com/user-attachments/assets/04843d8d-bbd3-482c-9946-4d653e0d678c)

