### PR TITLE
Feature/#73 contents header 컴포넌트

### DIFF
--- a/components/Dropdown.tsx
+++ b/components/Dropdown.tsx
@@ -47,6 +47,8 @@ export default function Dropdown({
           src="/icon/icon-arrowdown.svg"
           className={`size-4 ${isOpen ? 'rotate-180' : 'rotate-0'}`}
           alt="드롭다운 화살표"
+          width={7}
+          height={4}
         />
       </button>
 

--- a/components/Headers/Login.tsx
+++ b/components/Headers/Login.tsx
@@ -74,6 +74,8 @@ export default function Login({
           src={profileImage || '/icon/icon-profile.svg'}
           className="mo:hidden"
           alt="프로필 아이콘"
+          width={32}
+          height={32}
         />
         <Image
           src="/icon/icon-menu.svg"

--- a/components/LinkBar.tsx
+++ b/components/LinkBar.tsx
@@ -18,7 +18,7 @@ export default function LinkBar({ link, onClick }: LinkBarProps) {
       className="flex cursor-pointer items-center gap-[5px] rounded-custom bg-green-100 px-[10px] py-[3px] mo:py-1"
     >
       <Image
-        src="icon/icon-link.svg"
+        src="/icon/icon-link.svg"
         alt="링크 아이콘"
         className="mo:size-4"
         width={20}

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -24,7 +24,7 @@ export default function Menu({ options, onSelect, menuSize }: MenuProps) {
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') onSelect(option);
           }}
-          className={`w-auto cursor-pointer rounded-md px-3 py-2.5 hover:bg-green-100`}
+          className={`flex w-full cursor-pointer flex-col rounded-md px-3 py-2.5 hover:bg-green-100`}
         >
           {option}
         </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,6 +394,111 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.1.tgz",
+      "integrity": "sha512-h567/b/AHAnMpaJ1D3l3jKLrzNOgN9bmDSRd+Gb0hXTkLZh8mE0Kd9MbIw39QeTZQJ3192uFRFWlDjWiifwVhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.1.tgz",
+      "integrity": "sha512-I5Q6M3T9jzTUM2JlwTBy/VBSX+YCDvPLnSaJX5wE5GEPeaJkipMkvTA9+IiFK5PG5ljXTqVFVUj5BSHiYLCpoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.1.tgz",
+      "integrity": "sha512-4cPMSYmyXlOAk8U04ouEACEGnOwYM9uJOXZnm9GBXIKRbNEvBOH9OePhHiDWqOws6iaHvGayaKr+76LmM41yJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.1.1.tgz",
+      "integrity": "sha512-KgIiKDdV35KwL9TrTxPFGsPb3J5RuDpw828z3MwMQbWaOmpp/T4MeWQCwo+J2aOxsyAcfsNE334kaWXCb6YTTA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.1.tgz",
+      "integrity": "sha512-aHP/29x8loFhB3WuW2YaWaYFJN389t6/SBsug19aNwH+PRLzDEQfCvtuP6NxRCido9OAoExd+ZuYJKF9my1Kpg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.1.tgz",
+      "integrity": "sha512-klbzXYwqHMwiucNFF0tWiWJyPb45MBX1q/ATmxrMjEYgA+V/0OXc9KmNVRIn6G/ab0ASUk4uWqxik5m6wvm1sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.1.tgz",
+      "integrity": "sha512-V5fm4aULqHSlMQt3U1rWAWuwJTFsb6Yh4P8p1kQFoayAF9jAQtjBvHku4zCdrtQuw9u9crPC0FNML00kN4WGhA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",

--- a/pages/test/wiki/index.tsx
+++ b/pages/test/wiki/index.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+import Button from '@/components/Button';
+import ContentHeader from '@/pages/wiki/components/ContentHeader';
+
+export default function TestWiki() {
+  const [isEditing, setIsEditing] = useState(false);
+  const [newName, setNewName] = useState<string>('테스트');
+
+  const handleNameChange = (value: string) => {
+    setNewName(value);
+  };
+
+  const handleEditing = () => {
+    setIsEditing(!isEditing);
+  };
+
+  return (
+    <div className="mt-[120px]">
+      <ContentHeader
+        name={newName}
+        link="https://www.codeit.kr"
+        onNameChange={handleNameChange}
+        isEditing={isEditing}
+      />
+      <Button onClick={handleEditing}>isEditing?</Button>
+    </div>
+  );
+}

--- a/pages/wiki/components/Blank.tsx
+++ b/pages/wiki/components/Blank.tsx
@@ -21,7 +21,7 @@ export default function Blank({ onQuizSuccess, question, answer }: BlankProps) {
   const onQuizClose = () => setIsQuizOpen(false);
 
   return (
-    <div className="flex h-[192px] w-full flex-col items-center justify-center gap-[20px] rounded-custom bg-gray-100 text-gray-400 mo:h-[184px] mo:gap-[16px]">
+    <div className="mt-[56px] flex h-[192px] w-full flex-col items-center justify-center gap-[20px] rounded-custom bg-gray-100 text-gray-400 mo:h-[184px] mo:gap-[16px]">
       <div className="text-center text-16 mo:text-14">
         <p>아직 작성된 내용이 없네요.</p>
         <p>위키에 참여해 보세요!</p>

--- a/pages/wiki/components/ContentHeader.tsx
+++ b/pages/wiki/components/ContentHeader.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
+
 import InputField from '@/components/Input';
 import LinkBar from '@/components/LinkBar';
 import SnackBar from '@/components/SnackBar';
-import { useState } from 'react';
 
 interface ContentHeaderProps {
   name: string;
@@ -33,7 +34,7 @@ export default function ContentHeader({
         setSnackState('success');
         setTimeout(() => setSnackState('null'), 1500);
       })
-      .catch((error) => {
+      .catch(() => {
         alert('링크 복사에 실패했습니다.');
       });
   };

--- a/pages/wiki/components/ContentHeader.tsx
+++ b/pages/wiki/components/ContentHeader.tsx
@@ -1,0 +1,41 @@
+import InputField from '@/components/Input';
+import LinkBar from '@/components/LinkBar';
+
+interface ContentHeaderProps {
+  name: string;
+  link: string;
+  onNameChange: (value: string) => void;
+  isEditing: boolean;
+}
+
+/**
+ * Content 컴포넌트의 헤더에 해당하는 컴포넌트
+ * @param name 위키문서의 이름
+ * @param link 위키문서의 링크
+ * @param onNameChange 이름이 변경될 때 호출되는 콜백 함수
+ * @param isEditing 편집 모드인지 여부
+ */
+
+export default function ContentHeader({
+  name,
+  link,
+  onNameChange,
+  isEditing,
+}: ContentHeaderProps) {
+  return (
+    <div>
+      <div className="mb-[32px] flex items-center justify-between text-48sb text-gray-500 mo:mb-[24px] mo:text-32sb">
+        {isEditing ? (
+          <InputField
+            type="text"
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+          />
+        ) : (
+          <span>{name}</span>
+        )}
+      </div>
+      {!isEditing && <LinkBar link={link} />}
+    </div>
+  );
+}

--- a/pages/wiki/components/ContentHeader.tsx
+++ b/pages/wiki/components/ContentHeader.tsx
@@ -25,6 +25,7 @@ export default function ContentHeader({
   return (
     <div>
       <div className="mb-[32px] flex items-center justify-between text-48sb text-gray-500 mo:mb-[24px] mo:text-32sb">
+        {/*TODO 인풋 스타일은 일단 임시로 잡아놨습니다*/}
         {isEditing ? (
           <InputField
             type="text"

--- a/pages/wiki/components/ContentHeader.tsx
+++ b/pages/wiki/components/ContentHeader.tsx
@@ -1,5 +1,7 @@
 import InputField from '@/components/Input';
 import LinkBar from '@/components/LinkBar';
+import SnackBar from '@/components/SnackBar';
+import { useState } from 'react';
 
 interface ContentHeaderProps {
   name: string;
@@ -22,6 +24,19 @@ export default function ContentHeader({
   onNameChange,
   isEditing,
 }: ContentHeaderProps) {
+  const [snackState, setSnackState] = useState<'success' | 'null'>('null');
+
+  const handleLinkClick = () => {
+    navigator.clipboard
+      .writeText(link)
+      .then(() => {
+        setSnackState('success');
+        setTimeout(() => setSnackState('null'), 1500);
+      })
+      .catch((error) => {
+        alert('링크 복사에 실패했습니다.');
+      });
+  };
   return (
     <div>
       <div className="mb-[32px] flex items-center justify-between text-48sb text-gray-500 mo:mb-[24px] mo:text-32sb">
@@ -36,7 +51,9 @@ export default function ContentHeader({
           <span>{name}</span>
         )}
       </div>
-      {!isEditing && <LinkBar link={link} />}
+      {!isEditing && <LinkBar link={link} onClick={handleLinkClick} />}
+
+      {snackState !== 'null' && <SnackBar state={snackState} />}
     </div>
   );
 }


### PR DESCRIPTION
## 이슈 번호

close #73 

## 변경 사항 요약

- 위키 페이지의 이름과 링크를 포함하는 컴포넌트입니다.

## Doc

| **Props** | **Type** | **Description** |
| --------- | -------- | --------------- |
| ` name`      | `string  `     | 위키문서의 이름       |
| `link `      | ` string `     | 위키문서의 링크       |
| `onNameChange `      | ` function `     | 이름이 변경될 때 호출되는 콜백 함수    |
| `isEditing `      | ` boolean `     | 편집 모드인지 여부  |

## 테스트 결과

![image](https://github.com/user-attachments/assets/04843d8d-bbd3-482c-9946-4d653e0d678c)



- 커밋이 꼬인 것 같아 다시 올립니다.