### PR TITLE
Feature/#102 위키 목록 페이지 리스트 아이템 컴포넌트

### DIFF
--- a/pages/wikilist/ListItem.tsx
+++ b/pages/wikilist/ListItem.tsx
@@ -15,10 +15,15 @@ interface ListItemProps {
   };
 }
 
+/**
+ * 위키 목록 페이지 리스트 아이템 컴포넌트
+ * @param data - 목록에 출력할 프로필 데이터
+ */
 export default function ListItem({ data }: ListItemProps) {
   const { name, code, image, city, nationality, job } = data;
   const url = `https://www.wikied.kr/${code}`;
 
+  // 링크바 클릭 핸들러 함수
   const handleLinkClick = () => {
     navigator.clipboard.writeText(url);
     // TODO: 스낵바로 변경

--- a/pages/wikilist/ListItem.tsx
+++ b/pages/wikilist/ListItem.tsx
@@ -1,0 +1,58 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import LinkBar from '@/components/LinkBar';
+
+interface ListItemProps {
+  data: {
+    id: number;
+    name: string;
+    code: string;
+    image: string;
+    city: string;
+    nationality: string;
+    job: string;
+  };
+}
+
+export default function ListItem({ data }: ListItemProps) {
+  const { name, code, image, city, nationality, job } = data;
+  const url = `https://www.wikied.kr/${code}`;
+
+  const handleLinkClick = () => {
+    navigator.clipboard.writeText(url);
+    // TODO: 스낵바로 변경
+    alert(`${name}님 위키 링크가 복사되었습니다.`);
+  };
+
+  return (
+    <li className="relative rounded-custom shadow-custom transition-all hover:bg-gray-100 hover:shadow-xl dark:shadow-custom-dark">
+      <Link
+        href={`/wiki/${code}`}
+        className="flex gap-8 rounded-full px-9 py-6 mo:gap-5 mo:px-6 mo:py-5"
+      >
+        <Image
+          src={image || '/icon/icon-profile.svg'}
+          className="self-start rounded-full mo:size-[60px]"
+          width="85"
+          height="85"
+          alt={`${name} 프로필 이미지`}
+        />
+        <div className="mr-auto mo:mb-10">
+          <h2 className="mb-[14px] text-24sb mo:mb-[10px] mo:text-20sb">
+            {name}
+          </h2>
+          <p className="text-14 text-gray-400 mo:text-12">
+            {city}, {nationality}
+            <br />
+            {job}
+          </p>
+        </div>
+      </Link>
+
+      <div className="absolute bottom-6 right-9 ml-auto mt-[14px] self-end">
+        <LinkBar link={url} onClick={handleLinkClick} />
+      </div>
+    </li>
+  );
+}

--- a/pages/wikilist/ListItem.tsx
+++ b/pages/wikilist/ListItem.tsx
@@ -2,7 +2,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import LinkBar from '@/components/LinkBar';
-
 import type { ProfileProps } from '@/pages/wikilist';
 
 interface ListItemProps {

--- a/pages/wikilist/ListItem.tsx
+++ b/pages/wikilist/ListItem.tsx
@@ -3,16 +3,10 @@ import Link from 'next/link';
 
 import LinkBar from '@/components/LinkBar';
 
+import type { ProfileProps } from '@/pages/wikilist';
+
 interface ListItemProps {
-  data: {
-    id: number;
-    name: string;
-    code: string;
-    image: string;
-    city: string;
-    nationality: string;
-    job: string;
-  };
+  data: ProfileProps;
 }
 
 /**
@@ -21,13 +15,21 @@ interface ListItemProps {
  */
 export default function ListItem({ data }: ListItemProps) {
   const { name, code, image, city, nationality, job } = data;
-  const url = `https://www.wikied.kr/${code}`;
+  const shortUrl = `https://www.wikied.kr/${code.slice(0, 4)}...`;
+  const baseProfileImage = '/icon/icon-profile.svg';
 
   // 링크바 클릭 핸들러 함수
   const handleLinkClick = () => {
-    navigator.clipboard.writeText(url);
+    navigator.clipboard.writeText(`https://www.wikied.kr/${code}`);
     // TODO: 스낵바로 변경
     alert(`${name}님 위키 링크가 복사되었습니다.`);
+  };
+
+  // 이미지 로딩 실패 시 대체 이미지 처리 함수
+  const handleError = (event: React.SyntheticEvent<HTMLImageElement>) => {
+    const target = event.currentTarget;
+    target.srcset = '';
+    target.src = baseProfileImage;
   };
 
   return (
@@ -37,11 +39,12 @@ export default function ListItem({ data }: ListItemProps) {
         className="flex gap-8 rounded-full px-9 py-6 mo:gap-5 mo:px-6 mo:py-5"
       >
         <Image
-          src={image || '/icon/icon-profile.svg'}
+          src={image || baseProfileImage}
           className="self-start rounded-full mo:size-[60px]"
           width="85"
           height="85"
           alt={`${name} 프로필 이미지`}
+          onError={handleError}
         />
         <div className="mr-auto mo:mb-10">
           <h2 className="mb-[14px] text-24sb mo:mb-[10px] mo:text-20sb">
@@ -55,8 +58,8 @@ export default function ListItem({ data }: ListItemProps) {
         </div>
       </Link>
 
-      <div className="absolute bottom-6 right-9 ml-auto mt-[14px] self-end">
-        <LinkBar link={url} onClick={handleLinkClick} />
+      <div className="absolute bottom-6 right-9 ml-auto mt-[14px] self-end text-ellipsis mo:bottom-5 mo:right-6">
+        <LinkBar link={shortUrl} onClick={handleLinkClick} />
       </div>
     </li>
   );


### PR DESCRIPTION
## 이슈 번호

close #102 

## 변경 사항 요약

- 위키 목록 페이지에서 아이템 컴포넌트 분리

## Doc

_`컴포넌트 인 경우 props를 입력해주세요`_

| **Props** | **Type** | **Description** |
| --------- | -------- | --------------- |
| `data`      | `ListItemProps`     | 프로필 데이터       |

## 테스트 결과

![image](https://github.com/user-attachments/assets/b5695b9e-0e35-431d-b2c8-3dabb3468ed3)
![image](https://github.com/user-attachments/assets/693ceae5-253a-4253-b02f-422fc82dbc0f)
