### PR TITLE
✨ 계정 설정 페이지 UI API

### DIFF
--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -121,74 +121,87 @@ function MyPage(): React.ReactElement {
 
   const isWikiFormValid = question.trim() !== '' && answer.trim() !== '';
 
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <form onSubmit={handleSubmit}>
-        <div className="flex flex-col items-center gap-[32px] px-[16px] py-[48px]">
-          <h2 className="mb-[40px] text-center text-24sb text-gray-500 mo:mb-[8px] ta:mb-[24px]">
-            계정설정
-          </h2>
-          <div className="flex flex-col items-center gap-[8px]">
-            <InputField
-              label="비밀번호 변경"
-              type="password"
-              value={currentPassword}
-              onChange={handleCurrentPasswordChange}
-              placeholder="기존 비밀번호"
-            />
-            <InputField
-              label=""
-              type="password"
-              value={newPassword}
-              onChange={handleNewPasswordChange}
-              placeholder="새 비밀번호"
-            />
-            <InputField
-              label=""
-              type="password"
-              value={newPasswordConfirm}
-              onChange={handleNewPasswordConfirmChange}
-              placeholder="새 비밀번호 확인"
-            />
+  const inputSectionStyle = 'flex w-full flex-col items-center gap-[8px]';
+  const inputContainerStyle = 'flex w-full flex-col gap-[8px]';
 
-            <Button
-              type="submit"
-              disabled={!isPasswordFormValid}
-              isLoading={isSubmitting}
-              variant="primary"
-              size="small"
-              className="mt-[8px] self-end"
-            >
-              변경하기
-            </Button>
-            {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
+  return (
+    <div className="flex min-h-screen justify-center pt-[221px] mo:pt-[108px]">
+      <form onSubmit={handleSubmit} className="w-[400px] mo:w-[355px]">
+        <div className="flex w-full flex-col items-center gap-[32px]">
+          <h2 className="mb-[32px] text-center text-24sb text-gray-500">
+            계정설정
+          </h2>{' '}
+          <div className={inputSectionStyle}>
+            <div className={inputContainerStyle}>
+              <InputField
+                label="비밀번호 변경"
+                type="password"
+                value={currentPassword}
+                width="100%"
+                onChange={handleCurrentPasswordChange}
+                placeholder="기존 비밀번호"
+              />
+              <InputField
+                label=""
+                type="password"
+                value={newPassword}
+                width="100%"
+                onChange={handleNewPasswordChange}
+                placeholder="새 비밀번호"
+              />
+              <InputField
+                label=""
+                type="password"
+                value={newPasswordConfirm}
+                width="100%"
+                onChange={handleNewPasswordConfirmChange}
+                placeholder="새 비밀번호 확인"
+              />
+
+              <Button
+                type="submit"
+                disabled={!isPasswordFormValid}
+                isLoading={isSubmitting}
+                variant="primary"
+                size="small"
+                className="mt-[8px] self-end"
+              >
+                변경하기
+              </Button>
+              {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
+            </div>{' '}
           </div>
-          <div className="flex flex-col items-center gap-[8px]">
-            <InputField
-              label="위키 생성하기"
-              type="text"
-              value={question}
-              onChange={handleQuestionChange}
-              placeholder="질문을 입력해 주세요"
-            />
-            <InputField
-              label=""
-              type="text"
-              value={answer}
-              onChange={handleAnswerChange}
-              placeholder="답을 입력해 주세요"
-            />
-            <Button
-              type="submit"
-              disabled={!isWikiFormValid}
-              isLoading={isSubmitting}
-              variant="primary"
-              size="small"
-              className="mt-[8px] self-end"
-              onClick={(e) => handleWikiSubmit(e)}
-            >
-              생성하기
-            </Button>{' '}
+          <div className="w-full border-b border-gray-200"></div>
+          <div className={inputSectionStyle}>
+            <div className={inputContainerStyle}>
+              <InputField
+                label="위키 생성하기"
+                type="text"
+                value={question}
+                width="100%"
+                onChange={handleQuestionChange}
+                placeholder="질문을 입력해 주세요"
+              />
+              <InputField
+                label=""
+                type="text"
+                value={answer}
+                width="100%"
+                onChange={handleAnswerChange}
+                placeholder="답을 입력해 주세요"
+              />
+              <Button
+                type="submit"
+                disabled={!isWikiFormValid}
+                isLoading={isSubmitting}
+                variant="primary"
+                size="small"
+                className="mt-[8px] self-end"
+                onClick={(e) => handleWikiSubmit(e)}
+              >
+                생성하기
+              </Button>{' '}
+            </div>
           </div>
         </div>
       </form>

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -1,0 +1,199 @@
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+import Button from '@/components/Button';
+import InputField from '@/components/Input';
+import { useValidation } from '@/hooks/useValidation';
+import { AuthAPI } from '@/services/api/auth';
+import { ProfileAPI } from '@/services/api/profileAPI';
+
+function MyPage(): React.ReactElement {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [newPasswordConfirm, setNewPasswordConfirm] = useState('');
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  const currentPasswordValidation = useValidation({ type: 'password' });
+  const newPasswordValidation = useValidation({ type: 'password' });
+  const newPasswordConfirmValidation = useValidation({
+    type: 'passwordConfirm',
+    compareValue: newPassword,
+  });
+
+  const handleCurrentPasswordChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const value = e.target.value;
+    setCurrentPassword(value);
+    currentPasswordValidation.validate(value);
+  };
+
+  const handleNewPasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setNewPassword(value);
+    newPasswordValidation.validate(value);
+    // 새 비밀번호가 변경되면 확인 비밀번호도 다시 검증
+    if (newPasswordConfirm) {
+      newPasswordConfirmValidation.validate(newPasswordConfirm);
+    }
+  };
+
+  const handleNewPasswordConfirmChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const value = e.target.value;
+    setNewPasswordConfirm(value);
+    newPasswordConfirmValidation.validate(value);
+  };
+
+  const handleQuestionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuestion(e.target.value);
+  };
+
+  const handleAnswerChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setAnswer(e.target.value);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+    setError('');
+
+    try {
+      await AuthAPI.changePassword({
+        currentPassword,
+        newPassword,
+        newPasswordConfirm,
+      });
+
+      // 성공 시 로그인 페이지로 이동
+      router.push('/login');
+    } catch (error) {
+      if (error instanceof Error) {
+        setError(error.message);
+      } else {
+        setError('비밀번호가 일치하지 않습니다.');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // 위키 생성 제출
+  const handleWikiSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+    setError('');
+
+    try {
+      // 프로필 생성 API 호출
+      await ProfileAPI.createProfile({
+        securityQuestion: question,
+        securityAnswer: answer,
+      });
+
+      // 성공 시 위키 목록 페이지로 이동
+      router.push('/wiki/{code}');
+    } catch (error) {
+      if (error instanceof Error) {
+        setError(error.message);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+  // 비밀번호 변경 폼 유효성 검사
+  const isPasswordFormValid =
+    currentPassword &&
+    newPassword &&
+    newPasswordConfirm &&
+    !currentPasswordValidation.errorMessage &&
+    !newPasswordValidation.errorMessage &&
+    !newPasswordConfirmValidation.errorMessage;
+
+  const isWikiFormValid = question.trim() !== '' && answer.trim() !== '';
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit}>
+        <div className="flex flex-col items-center gap-[32px] px-[16px] py-[48px]">
+          <h2 className="mb-[40px] text-center text-24sb text-gray-500 mo:mb-[8px] ta:mb-[24px]">
+            계정설정
+          </h2>
+          <div className="flex flex-col items-center gap-[8px]">
+            <InputField
+              label="비밀번호 변경"
+              type="password"
+              value={currentPassword}
+              onChange={handleCurrentPasswordChange}
+              placeholder="기존 비밀번호"
+            />
+            <InputField
+              label=""
+              type="password"
+              value={newPassword}
+              onChange={handleNewPasswordChange}
+              placeholder="새 비밀번호"
+            />
+            <InputField
+              label=""
+              type="password"
+              value={newPasswordConfirm}
+              onChange={handleNewPasswordConfirmChange}
+              placeholder="새 비밀번호 확인"
+            />
+
+            <Button
+              type="submit"
+              disabled={!isPasswordFormValid}
+              isLoading={isSubmitting}
+              variant="primary"
+              size="small"
+              className="mt-[8px] self-end"
+            >
+              변경하기
+            </Button>
+            {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
+          </div>
+          <div className="flex flex-col items-center gap-[8px]">
+            <InputField
+              label="위키 생성하기"
+              type="text"
+              value={question}
+              onChange={handleQuestionChange}
+              placeholder="질문을 입력해 주세요"
+            />
+            <InputField
+              label=""
+              type="text"
+              value={answer}
+              onChange={handleAnswerChange}
+              placeholder="답을 입력해 주세요"
+            />
+            <Button
+              type="submit"
+              disabled={!isWikiFormValid}
+              isLoading={isSubmitting}
+              variant="primary"
+              size="small"
+              className="mt-[8px] self-end"
+              onClick={(e) => handleWikiSubmit(e)}
+            >
+              생성하기
+            </Button>{' '}
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default MyPage;

--- a/services/api/auth.ts
+++ b/services/api/auth.ts
@@ -3,33 +3,6 @@ import { AxiosError } from 'axios';
 import instance from '../../lib/axios-client';
 
 export const AuthAPI = {
-  signup: async (data: {
-    email: string;
-    name: string;
-    password: string;
-    passwordConfirmation: string;
-  }) => {
-    try {
-      const res = await instance.post('/auth/signUp', data);
-      return res.data;
-    } catch (error) {
-      if (error instanceof AxiosError) {
-        // 400 에러 (이미 존재하는 이메일)
-        if (error.response?.status === 400) {
-          throw new Error(error.response.data.message);
-        }
-        // 500 에러 (서버 내부 오류)
-        if (error.response?.status === 500) {
-          throw new Error(
-            '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
-          );
-        }
-      }
-      // 기타 예상치 못한 에러
-      throw new Error('회원가입 중 오류가 발생했습니다.');
-    }
-  },
-
   signin: async (data: { email: string; password: string }) => {
     try {
       const res = await instance.post('/auth/signIn', data);
@@ -44,17 +17,87 @@ export const AuthAPI = {
       if (error instanceof AxiosError) {
         // 400 에러 (이메일 또는 비밀번호 불일치)
         if (error.response?.status === 400) {
-          throw new Error('이메일 또는 비밀번호가 일치하지 않습니다.');
+          throw new Error('이메일 또는 비밀번호가 일치하지 않습니다.'); //TODO 스낵바로 예쁘게 만들기
         }
         // 500 에러 (서버 내부 오류)
         if (error.response?.status === 500) {
           throw new Error(
-            '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
+            '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' //TODO 스낵바로 예쁘게 만들기
           );
         }
       }
       // 기타 예상치 못한 에러
-      throw new Error('로그인 중 오류가 발생했습니다.');
+      throw new Error('로그인 중 오류가 발생했습니다.'); //TODO 스낵바로 예쁘게 만들기
+    }
+  },
+
+  signup: async (data: {
+    email: string;
+    name: string;
+    password: string;
+    passwordConfirmation: string;
+  }) => {
+    try {
+      const res = await instance.post('/auth/signUp', data);
+      return res.data;
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        // 400 에러 (이미 존재하는 이메일)
+        if (error.response?.status === 400) {
+          throw new Error('이미 존재하는 이메일입니다.'); //TODO 스낵바로 예쁘게 만들기
+        }
+        // 500 에러 (서버 내부 오류)
+        if (error.response?.status === 500) {
+          throw new Error(
+            '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' //TODO 스낵바로 예쁘게 만들기
+          );
+        }
+      }
+      // 기타 예상치 못한 에러
+      throw new Error('회원가입 중 오류가 발생했습니다.'); //TODO 스낵바로 예쁘게 만들기
+    }
+  },
+
+  changePassword: async (data: {
+    currentPassword: string;
+    newPassword: string;
+    newPasswordConfirm: string;
+  }) => {
+    try {
+      // 새 비밀번호 일치 여부 확인
+      if (data.newPassword !== data.newPasswordConfirm) {
+        throw new Error('비밀번호가 일치하지 않습니다.'); //TODO 스낵바로 예쁘게 만들기
+      }
+
+      // 기존 비밀번호와 새 비밀번호가 같은지 확인
+      if (data.currentPassword === data.newPassword) {
+        throw new Error('현재 비밀번호와 새 비밀번호가 같습니다.'); //TODO 스낵바로 예쁘게 만들기
+      }
+
+      // 비밀번호 변경 API 호출
+      const res = await instance.patch('/users/me/password', {
+        currentPassword: data.currentPassword,
+        password: data.newPassword,
+        passwordConfirmation: data.newPasswordConfirm,
+      });
+      return res.data;
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        // 400 에러 (현재 비밀번호 불일치)
+        if (error.response?.status === 400) {
+          throw new Error('현재 비밀번호가 일치하지 않습니다.'); //TODO 스낵바로 예쁘게 만들기
+        }
+        // 500 에러 (서버 내부 오류)
+        if (error.response?.status === 500) {
+          throw new Error(
+            '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' //TODO 스낵바로 예쁘게 만들기
+          );
+        }
+      }
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('비밀번호 변경 중 오류가 발생했습니다.'); //TODO 스낵바로 예쁘게 만들기
     }
   },
 };


### PR DESCRIPTION
## 이슈 번호

close #61 

## 변경 사항 요약

- 계정설정페이지 UI구현, API연결했습니다 
- 인풋 너비 수정은 이슈생성해서 해당 이슈에서 수정하겠습니다.
- 비밀번호 변경 성공시 로그인 화면으로 이동합니다
- 위키 생성하기 성공시 내 위키 화면으로 이동합니다. (내위키는 한번만 생성이 가능하므로 안내문구나 수정이 가능한 기능이 추가되면 좋을 것 같습니다)

## Doc

_`컴포넌트 인 경우 props를 입력해주세요`_

| **Props** | **Type** | **Description** |
| --------- | -------- | --------------- |
| `  `      | `  `     | 내용 입력       |
| `  `      | `  `     | 내용 입력       |

_`hooks 및 utils 인 경우 input,output을 입력해주세요`_

|            | **prams** | **Type** | **Description** |
| ---------- | --------- | -------- | --------------- |
| **input**  | `  `      | `  `     | 내용 입력       |
| **output** | `  `      | `  `     | 내용 입력       |

## 테스트 결과
<img width="992" alt="iShot_2024-12-21_02 00 47" src="https://github.com/user-attachments/assets/ec3f45cf-c020-4e9c-b57c-f26317ba5c59" />

_`베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.`_
_`컴포넌트의 경우 스크린샷을 포함해주세요.`_
