### PR TITLE
💄 인풋컴포넌트 너비 props로 지정

### DIFF
--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -73,7 +73,7 @@ function InputField({
   //스타일에 따른 클래스
   const variantClass = {
     containerVertical: 'flex flex-col gap-[10px]',
-    containerHorizontal: 'w-[239px] flex items-center gap-[10px]',
+    containerHorizontal: 'flex items-center gap-[10px]',
     labelVertical: 'text-14 text-gray-500',
     labelHorizontal: 'text-14 text-gray-400 w-[60px] flex-shrink-0',
     base: 'px-[20px] py-[10px] h-[45px] w-full rounded-md text-[14px] text-gray-500 placeholder:text-14 focus:outline-none',
@@ -101,6 +101,7 @@ function InputField({
           ? `${variantClass.containerHorizontal} relative`
           : `${variantClass.containerVertical} relative`
       }
+      style={width ? { width } : undefined}
     >
       {label && <label className={labelClass}>{label}</label>}
       <input

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -11,6 +11,7 @@ interface InputFieldProps {
   label?: string;
   compareValue?: string;
   layout?: 'vertical' | 'horizontal';
+  width?: string;
   onValidation?: (isValid: boolean) => void;
   ref?: React.Ref<HTMLInputElement>;
 }
@@ -23,6 +24,7 @@ function InputField({
   label,
   compareValue,
   layout = 'vertical',
+  width,
   onValidation,
   ref,
   ...props

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -62,8 +62,8 @@ function Login(): React.ReactElement {
   const isFormValid = Object.values(validFields).every(Boolean);
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <form onSubmit={handleSubmit}>
+    <div className="flex min-h-screen justify-center pt-[233px] mo:pt-[203px]">
+      <form onSubmit={handleSubmit} className="w-[400px] mo:w-[355px]">
         <div className="flex flex-col items-center gap-[24px]">
           <h2 className="mb-[40px] text-center text-24sb text-gray-500 mo:mb-[8px] ta:mb-[24px]">
             로그인
@@ -72,6 +72,7 @@ function Login(): React.ReactElement {
             label="이메일"
             type="email"
             value={email}
+            width="100%"
             onChange={handleEmailChange}
             placeholder="이메일을 입력해 주세요"
             onValidation={(isValid) => handleValidation('email', isValid)}
@@ -80,6 +81,7 @@ function Login(): React.ReactElement {
             label="비밀번호"
             type="password"
             value={password}
+            width="100%"
             onChange={handlePasswordChange}
             placeholder="비밀번호를 입력해 주세요"
             onValidation={(isValid) => handleValidation('password', isValid)}
@@ -89,7 +91,7 @@ function Login(): React.ReactElement {
             disabled={!isFormValid}
             isLoading={isSubmitting}
             variant="primary"
-            className="mt-[6px] h-[45px] w-[400px] mo:w-[355px]"
+            className="mt-[6px] h-[45px] w-full"
           >
             로그인
           </Button>

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -79,8 +79,8 @@ function SignUp() {
   const isFormValid = Object.values(validFields).every(Boolean);
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <form onSubmit={handleSubmit}>
+    <div className="flex min-h-screen justify-center pt-[233px] mo:pt-[108px]">
+      <form onSubmit={handleSubmit} className="w-[400px] mo:w-[355px]">
         <div className="flex flex-col items-center gap-[24px]">
           <h2 className="mb-[40px] text-center text-24sb text-gray-500 mo:mb-[8px] ta:mb-[24px]">
             회원가입
@@ -89,6 +89,7 @@ function SignUp() {
             label="이름"
             type="name"
             value={name}
+            width="100%"
             onChange={handleNameChange}
             placeholder="이름을 입력해 주세요"
             onValidation={(isValid) => handleValidation('name', isValid)}
@@ -97,6 +98,7 @@ function SignUp() {
             label="이메일"
             type="email"
             value={email}
+            width="100%"
             onChange={handleEmailChange}
             placeholder="이메일을 입력해 주세요"
             onValidation={(isValid) => handleValidation('email', isValid)}
@@ -105,6 +107,7 @@ function SignUp() {
             label="비밀번호"
             type="password"
             value={password}
+            width="100%"
             onChange={handlePasswordChange}
             placeholder="비밀번호를 입력해 주세요"
             onValidation={(isValid) => handleValidation('password', isValid)}
@@ -113,6 +116,7 @@ function SignUp() {
             label="비밀번호 확인"
             type="passwordConfirm"
             value={passwordConfirm}
+            width="100%"
             onChange={handlePasswordConfirmChange}
             placeholder="비밀번호를 다시 입력해 주세요"
             compareValue={password}
@@ -125,7 +129,7 @@ function SignUp() {
             disabled={!isFormValid}
             isLoading={isSubmitting}
             variant="primary"
-            className="mt-[6px] h-[45px] w-[400px] mo:w-[355px]"
+            className="mt-[6px] h-[45px] w-full"
           >
             가입하기
           </Button>


### PR DESCRIPTION
로그인,회원가입 화면 인풋너비 수정

## 이슈 번호

close #111

## 변경 사항 요약

- 인풋컴포넌트 width prop으로 너비 지정 해서 사용해주세요.
- 인풋 컴포넌트 너비의 기본값은 w-full 입니다 
- 로그아웃, 회원가입 화면 모바일일때 form영역 상단의 패딩값을 주었습니다. 



## Doc

_`컴포넌트 인 경우 props를 입력해주세요`_

| **Props** | **Type** | **Description** |
| --------- | -------- | --------------- |
| `  `      | `  `     | 내용 입력       |
| `  `      | `  `     | 내용 입력       |

_`hooks 및 utils 인 경우 input,output을 입력해주세요`_

|            | **prams** | **Type** | **Description** |
| ---------- | --------- | -------- | --------------- |
| **input**  | `  `      | `  `     | 내용 입력       |
| **output** | `  `      | `  `     | 내용 입력       |

## 테스트 결과

_`베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.`_
_`컴포넌트의 경우 스크린샷을 포함해주세요.`_
