### PR TITLE
#120 에디터 컨텐츠 view 컴포넌트

### DIFF
--- a/components/EditorViewer.tsx
+++ b/components/EditorViewer.tsx
@@ -1,0 +1,11 @@
+/**
+ * @param {string} content - 에디터 리턴 content
+ */
+export default function EditorViewer({ content }: { content: string }) {
+  return (
+    <div
+      dangerouslySetInnerHTML={{ __html: content }}
+      className="contentStyle"
+    />
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -83,3 +83,61 @@ body {
     color: var(--gray-400);
   }
 }
+
+.contentStyle h1 {
+  @apply text-3xl;
+}
+.contentStyle h2 {
+  @apply text-2xl;
+}
+.contentStyle h3 {
+  @apply text-xl;
+}
+.contentStyle h1,
+.contentStyle h2,
+.contentStyle h3 {
+  @apply my-4 font-bold;
+}
+.contentStyle h1,
+.contentStyle h2 {
+  @apply border-b border-gray-200;
+}
+
+.contentStyle p {
+  @apply my-2;
+}
+
+.contentStyle ul,
+.contentStyle ol {
+  @apply my-2 list-inside;
+}
+
+.contentStyle ul {
+  @apply list-disc;
+}
+
+.contentStyle ol {
+  @apply list-decimal;
+}
+
+.contentStyle a {
+  @apply text-blue-500 underline;
+}
+
+.contentStyle blockquote {
+  @apply my-4 border-l-4 border-green-200 pl-4 italic;
+}
+
+.contentStyle pre {
+  @apply my-4 rounded bg-gray-100 p-4;
+}
+
+.contentStyle code {
+  @apply rounded bg-gray-100 px-1;
+}
+.contentStyle .ql-align-center {
+  @apply text-center;
+}
+.contentStyle .ql-align-right {
+  @apply text-right;
+}


### PR DESCRIPTION
## 이슈 번호

close #120 

## 변경 사항 요약

- 공통으로 쓸 수 있는 에디터 뷰어 입니다.
- props로 content 넘겨주시면 됩니다

## Doc

_`컴포넌트 인 경우 props를 입력해주세요`_

| **Props** | **Type** | **Description** |
| --------- | -------- | --------------- |
| `content`      | `string`     | 에디터 리턴 content       |

## 테스트 결과

_`베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.`_
_`컴포넌트의 경우 스크린샷을 포함해주세요.`_

![2024-12-21_6 56 03](https://github.com/user-attachments/assets/2d86bdd3-9617-46a9-8b4f-83f5942e8b3f)
