### PR TITLE
#101 snack bar 텍스트 커스텀 가능하게 수정

### DIFF
--- a/components/SnackBar.tsx
+++ b/components/SnackBar.tsx
@@ -1,52 +1,77 @@
 import Image from 'next/image';
+import { useEffect, useState } from 'react';
 
 interface SnackBarProps {
-  state: 'fail' | 'success' | 'info' | 'null';
+  severity: 'fail' | 'success' | 'info';
+  children: string;
+  open: boolean;
+  onClose: () => void;
+  autoHideDuration?: number | undefined;
 }
 
 // state props styles object
-const stateConfig = {
+const severityConfig = {
   fail: {
     style:
-      'bg-red-50 border-red-100 fixed left-1/2 transform -translate-x-1/2 top-[120px] mx-auto mo:bottom-[80px] mo:top-auto w-[384px] mo:w-[328px] whitespace-nowrap',
-    text: '다른 친구가 편집하고 있어요. 나중에 다시 시도해 주세요.',
+      'bg-red-50 border-red-100 fixed left-1/2 transform -translate-x-1/2 top-[120px] mx-auto mo:bottom-[80px] mo:top-auto whitespace-nowrap shadow-custom',
     icon: '/icon/icon-fail.svg',
     textStyle: 'text-red-100 text-14sb mo:text-12sb',
   },
   success: {
     style:
-      'bg-green-100 border-green-200 fixed left-1/2 transform -translate-x-1/2 top-[120px] mx-auto mo:bottom-[80px] mo:top-auto w-[247px] mo:w-[210px] whitespace-nowrap',
-    text: '내 위키 링크가 복사되었습니다.',
+      'bg-green-100 border-green-200 fixed left-1/2 transform -translate-x-1/2 top-[120px] mx-auto mo:bottom-[80px] mo:top-auto whitespace-nowrap shadow-custom',
     icon: '/icon/icon-success.svg',
     textStyle: 'text-green-300 text-14sb mo:text-12sb',
   },
   info: {
     style: 'bg-background border-white',
-    text: '앞 사람의 편집이 끝나면 위키 참여가 가능합니다.',
     icon: '/icon/icon-info.svg',
     textStyle: 'text-gray-500 text-14 mo:text-12',
-  },
-  null: {
-    style: 'hidden',
-    text: '',
-    icon: '',
-    textStyle: '',
   },
 };
 
 /**
  * SnackBar 컴포넌트
- * @param {SnackBarProps} { state } - state: 'fail' | 'success' | 'info' | 'null'
+ * @param severity - 상태에 따른 스타일을 적용하기 위한 props
+ * @param children - Snackbar에 표시할 메시지
+ * @param open - Snackbar가 열려있는지 여부
+ * @param onClose - Snackbar를 닫기 위한 함수
+ * @param autoHideDuration - 자동으로 닫히는 시간 (밀리초) 기본값은 3000
  */
-export default function SnackBar({ state }: SnackBarProps) {
-  const { style, text, icon, textStyle } = stateConfig[state];
+export default function SnackBar({
+  severity,
+  children,
+  open,
+  onClose,
+  autoHideDuration = 3000,
+}: SnackBarProps) {
+  const { style, icon, textStyle } = severityConfig[severity];
+  const [visible, setVisible] = useState(open);
+
+  useEffect(() => {
+    if (open) {
+      setVisible(true);
+      if (autoHideDuration !== undefined) {
+        const timer = setTimeout(() => {
+          setVisible(false);
+          setTimeout(onClose, 300);
+        }, autoHideDuration);
+        return () => clearTimeout(timer);
+      }
+    } else {
+      setVisible(false);
+    }
+  }, [open, autoHideDuration, onClose]);
 
   return (
     <div
-      className={`rounded-custom ${style} flex items-center gap-[15px] border px-5 py-[11px] shadow-custom mo:px-[15px] mo:py-[11px]`}
+      className={`rounded-custom ${style} flex items-center gap-[15px] border px-5 py-[11px] transition-opacity duration-300 mo:px-[15px] mo:py-[11px] ${
+        visible ? 'opacity-100' : 'opacity-0'
+      }`}
+      style={{ display: open || visible ? 'flex' : 'none' }}
     >
       {icon && <Image src={icon} alt="snackbar icon" width={20} height={20} />}
-      <p className={`${textStyle} break-words mo:break-words`}>{text}</p>
+      <p className={`${textStyle} break-words mo:break-words`}>{children}</p>
     </div>
   );
 }

--- a/pages/test/index.tsx
+++ b/pages/test/index.tsx
@@ -9,21 +9,49 @@ export default function Test() {
   const commonCellClass = 'border-r border-gray-300';
   const commonRowClass = 'flex flex-wrap items-end gap-2';
 
-  // ----snackBar(start)----
-  const [snackState, setSnackState] = useState<
-    'fail' | 'success' | 'info' | 'null'
-  >('null');
+  const [snackBarState, setSnackBarState] = useState<{
+    open: boolean;
+    severity: 'fail' | 'success' | 'info';
+    message: string;
+    autoHideDuration?: number;
+  }>({
+    open: false,
+    severity: 'info',
+    message: '',
+  });
 
-  const handleSuccess = () => {
-    setSnackState('success');
-    setTimeout(() => setSnackState('null'), 1500);
+  const handleErrorClick = () => {
+    setSnackBarState({
+      open: true,
+      severity: 'fail',
+      message: '에러가 발생했습니다.',
+      autoHideDuration: 3000,
+    });
   };
 
-  const handleFail = () => {
-    setSnackState('fail');
-    setTimeout(() => setSnackState('null'), 1500);
+  const handleSuccessClick = () => {
+    setSnackBarState({
+      open: true,
+      severity: 'success',
+      message: '성공적으로 처리되었습니다.',
+      autoHideDuration: 3000,
+    });
   };
-  // ----snackBar(end)----
+  const handleInfoClick = () => {
+    setSnackBarState({
+      open: true,
+      severity: 'info',
+      message: '안내 메세지 입니다.',
+      autoHideDuration: 3000,
+    });
+  };
+
+  const handleCloseSnackBar = () => {
+    setSnackBarState({
+      ...snackBarState,
+      open: false,
+    });
+  };
 
   //-----dropdown(start)-----
   const options = ['옵션1', '옵션2', '옵션3'];
@@ -82,10 +110,17 @@ export default function Test() {
           <tr className="border-b border-gray-300">
             <td className={commonCellClass}>SnackBar</td>
             <td className={commonRowClass}>
-              <SnackBar state="info" />
-              <Button onClick={handleSuccess}>복사</Button>
-              <Button onClick={handleFail}>에러</Button>
-              {snackState !== 'null' && <SnackBar state={snackState} />}
+              <SnackBar
+                severity={snackBarState.severity}
+                open={snackBarState.open}
+                onClose={handleCloseSnackBar}
+                autoHideDuration={snackBarState.autoHideDuration}
+              >
+                {snackBarState.message}
+              </SnackBar>
+              <Button onClick={handleInfoClick}>안내 메세지</Button>
+              <Button onClick={handleErrorClick}>에러 메세지</Button>
+              <Button onClick={handleSuccessClick}>완료 메세지</Button>
             </td>
           </tr>
           <tr className="border-b border-gray-300">


### PR DESCRIPTION
## 이슈 번호

close #101 

## 변경 사항 요약

- snackbar 텍스트 커스텀 가능하게 수정해두었습니다 그에 따라 props도 변경 되었으니 구버전 snackbar 작업하신 분은 변경 부탁드립니다
- 명확한 props 이름으로 변경하였고 open 상태, onClose 함수, autoHideDuration 추가 했습니다
- fadein, fadeout 모션도 추가 했습니다.
- material-ui 컴포넌트 참고하여 제작했습니다

## Doc

_`컴포넌트 인 경우 props를 입력해주세요`_

| **Props**           | **Type**           | **Description**                                |
|---------------------|--------------------|-----------------------------------------------|
| `severity`          | `string`          | 상태에 따른 스타일을 적용하기 위한 props       |
| `children`          | `React.ReactNode` | Snackbar에 표시할 메시지                       |
| `open`              | `boolean`         | Snackbar가 열려있는지 여부                     |
| `onClose`           | `function`        | Snackbar를 닫기 위한 함수                      |
| `autoHideDuration`  | `number`          | 자동으로 닫히는 시간 (밀리초). 기본값은 3000   |

## 테스트 결과

_`베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.`_
_`컴포넌트의 경우 스크린샷을 포함해주세요.`_

/test 페이지에서 확인 가능합니다
