### PR TITLE
🐛 rest props 타입 정의 추가

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -50,6 +50,7 @@ interface Props {
   isLoading?: boolean;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   children: ReactNode;
+  [key: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
## 이슈 번호

close #168 

## 변경 사항 요약

- 컴포넌트 에서는 오류가 없었지만 사용하는 쪽에서 오류 발생을 확인
- rest props 타입 정의 `[key: string]: unknown;` 추가