### PR TITLE
Feature/#188 상세 페이지 댓글 무한스크롤 react query

### DIFF
--- a/components/boards.page/Comment.tsx
+++ b/components/boards.page/Comment.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import React from 'react';
 import { useState } from 'react';
-import { Comment as CommentType, Writer } from 'types/board';
+import { CommentType, Writer } from 'types/board';
 
 import dateConversion from '@/utils/dateConversion';
 

--- a/services/api/commentAPI.ts
+++ b/services/api/commentAPI.ts
@@ -7,7 +7,7 @@ export const fetchComments = async (
   cursor: string | null
 ): Promise<CommentsData> => {
   const response = await instance.get(
-    `/articles/${articleId}/comments?limit=10${cursor ? `&cursor=${cursor}` : ''}`
+    `/articles/${articleId}/comments?limit=100${cursor ? `&cursor=${cursor}` : ''}`
   );
   return response.data;
 };

--- a/services/api/commentAPI.ts
+++ b/services/api/commentAPI.ts
@@ -1,0 +1,35 @@
+import instance from '@/lib/axios-client';
+import { CommentsData } from 'types/board';
+
+// 댓글 페칭 함수
+export const fetchComments = async (
+  articleId: string | string[] | undefined,
+  cursor: string | null
+): Promise<CommentsData> => {
+  const response = await instance.get(
+    `/articles/${articleId}/comments?limit=10${cursor ? `&cursor=${cursor}` : ''}`
+  );
+  return response.data;
+};
+
+// 댓글 추가 함수
+export const addComment = async (articleId: string, content: string) => {
+  const response = await instance.post(`/articles/${articleId}/comments`, {
+    content,
+  });
+  return response.data;
+};
+
+// 댓글 수정 함수
+export const updateComment = async (id: number, newContent: string) => {
+  const response = await instance.patch(`/comments/${id}`, {
+    content: newContent,
+  });
+  return response.data;
+};
+
+// 댓글 삭제 함수
+export const deleteComment = async (id: number) => {
+  const response = await instance.delete(`/comments/${id}`);
+  return response.data;
+};

--- a/types/board.ts
+++ b/types/board.ts
@@ -36,13 +36,13 @@ export interface BoardListResponse {
   data: Board[];
 }
 
-export interface Comment extends BaseEntity {
+export interface CommentType extends BaseEntity {
   content: string;
   writer: Writer;
 }
 
 export interface CommentsData {
-  list: Comment[];
+  list: CommentType[];
   nextCursor: string | null;
 }
 


### PR DESCRIPTION
## 이슈 번호

close #188 

## 변경 사항 요약

- react query 패칭을 이용해여 무한 스크롤 구현
- 아쉽게도 무한 스크롤 구현은 되었지만 댓글의 총개수를 표현하기위해서는 서버측에서 total값을 제공해주어야하는데 현 api에는 total값이 존재하지않아 limit=100 기준으로 재작성...
- comment api 분리
- type 네임과 컴포넌트 네임 혼동을 방지하기 위해 구분 작성

