### PR TITLE
🐛  비밀번호 변경되지 않은 오류 수정

### DIFF
--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -3,6 +3,7 @@ import React, { FormEvent, useState } from 'react';
 
 import Button from '@/components/Button';
 import InputField from '@/components/Input';
+import SnackBar from '@/components/SnackBar';
 import { useValidation } from '@/hooks/useValidation';
 import { AuthAPI } from '@/services/api/auth';
 import { ProfileAPI } from '@/services/api/profileAPI';
@@ -15,6 +16,7 @@ function MyPage(): React.ReactElement {
   const [answer, setAnswer] = useState('');
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
   const router = useRouter();
 
   const currentPasswordValidation = useValidation({ type: 'password' });
@@ -36,10 +38,6 @@ function MyPage(): React.ReactElement {
     const value = e.target.value;
     setNewPassword(value);
     newPasswordValidation.validate(value);
-    // 새 비밀번호가 변경되면 확인 비밀번호도 다시 검증
-    if (newPasswordConfirm) {
-      newPasswordConfirmValidation.validate(newPasswordConfirm);
-    }
   };
 
   const handleNewPasswordConfirmChange = (
@@ -77,6 +75,7 @@ function MyPage(): React.ReactElement {
     } catch (error) {
       if (error instanceof Error) {
         setError(error.message);
+        setSnackbarOpen(true);
       }
     } finally {
       setIsSubmitting(false);
@@ -117,12 +116,10 @@ function MyPage(): React.ReactElement {
       newPassword.length > 0 &&
       typeof newPasswordConfirm === 'string' &&
       newPasswordConfirm.length > 0 &&
-      typeof currentPasswordValidation.errorMessage === 'string' &&
-      currentPasswordValidation.errorMessage.length === 0 &&
-      typeof newPasswordValidation.errorMessage === 'string' &&
-      newPasswordValidation.errorMessage.length === 0 &&
-      typeof newPasswordConfirmValidation.errorMessage === 'string' &&
-      newPasswordConfirmValidation.errorMessage.length === 0
+      newPassword === newPasswordConfirm &&
+      !currentPasswordValidation.errorMessage &&
+      !newPasswordValidation.errorMessage &&
+      !newPasswordConfirmValidation.errorMessage
   );
 
   const isWikiFormValid = Boolean(
@@ -179,7 +176,6 @@ function MyPage(): React.ReactElement {
               >
                 변경하기
               </Button>
-              {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
             </div>{' '}
           </div>
           <div className="w-full border-b border-gray-200"></div>
@@ -201,20 +197,30 @@ function MyPage(): React.ReactElement {
                 onChange={handleAnswerChange}
                 placeholder="답을 입력해 주세요"
               />
+
               <Button
-                type="submit"
+                type="button"
                 disabled={!isWikiFormValid}
                 isLoading={Boolean(isSubmitting)}
                 variant="primary"
                 size="small"
                 className="mt-[8px] self-end"
-                onClick={(e) => handleWikiSubmit(e)}
+                onClick={handleWikiSubmit}
               >
                 생성하기
-              </Button>{' '}
+              </Button>
             </div>
           </div>
         </div>
+        {snackbarOpen && (
+          <SnackBar
+            severity="fail"
+            open={snackbarOpen}
+            onClose={() => setSnackbarOpen(false)}
+          >
+            {error}
+          </SnackBar>
+        )}
       </form>
     </div>
   );

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -159,10 +159,11 @@ function MyPage(): React.ReactElement {
               />
               <InputField
                 label=""
-                type="password"
+                type="passwordConfirm"
                 value={newPasswordConfirm}
                 width="100%"
                 onChange={handleNewPasswordConfirmChange}
+                compareValue={newPassword}
                 placeholder="새 비밀번호 확인"
               />
 


### PR DESCRIPTION
typeof 검사와 length 확인 제거

## 이슈 번호

close #190 

## 변경 사항 요약

- 비밀번호 변경되지 않는 오류 수정했습니다 
- 단순히 !errorMessage로 비어 있지 않음을 확인하도록 수정
- 새 비밀번호와 확인값 일치 여부 검사 추가
- AAPI 호출 실패 시의 에러시에는 스낵바로 표시되도록 수정

## Doc

_`컴포넌트 인 경우 props를 입력해주세요`_

| **Props** | **Type** | **Description** |
| --------- | -------- | --------------- |
| `  `      | `  `     | 내용 입력       |
| `  `      | `  `     | 내용 입력       |

_`hooks 및 utils 인 경우 input,output을 입력해주세요`_

|            | **prams** | **Type** | **Description** |
| ---------- | --------- | -------- | --------------- |
| **input**  | `  `      | `  `     | 내용 입력       |
| **output** | `  `      | `  `     | 내용 입력       |

## 테스트 결과

_`베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.`_
_`컴포넌트의 경우 스크린샷을 포함해주세요.`_
