### PR TITLE
⚡️ 패스워드 변경 안내문구

### DIFF
--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -7,6 +7,7 @@ import SnackBar from '@/components/SnackBar';
 import { useValidation } from '@/hooks/useValidation';
 import { AuthAPI } from '@/services/api/auth';
 import { ProfileAPI } from '@/services/api/profileAPI';
+import { AxiosError } from 'axios';
 
 function MyPage(): React.ReactElement {
   const [currentPassword, setCurrentPassword] = useState('');
@@ -14,8 +15,9 @@ function MyPage(): React.ReactElement {
   const [newPasswordConfirm, setNewPasswordConfirm] = useState('');
   const [question, setQuestion] = useState('');
   const [answer, setAnswer] = useState('');
-  const [error, setError] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<AxiosError | null>(null);
+  const [isPasswordSubmitting, setIsPasswordSubmitting] = useState(false);
+  const [isWikiSubmitting, setIsWikiSubmitting] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const router = useRouter();
 
@@ -56,12 +58,12 @@ function MyPage(): React.ReactElement {
     setAnswer(e.target.value);
   };
 
-  const handleSubmit = async (e: FormEvent) => {
+  const handlePasswordSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (isSubmitting) return;
+    if (isPasswordSubmitting) return;
 
-    setIsSubmitting(true);
-    setError('');
+    setIsPasswordSubmitting(true);
+    setError(null);
 
     try {
       await AuthAPI.changePassword({
@@ -70,25 +72,35 @@ function MyPage(): React.ReactElement {
         newPasswordConfirm,
       });
 
-      // 성공 시 로그인 페이지로 이동
-      await router.push('/login');
+      setSnackbarOpen(true);
+      setCurrentPassword('');
+      setNewPassword('');
+      setNewPasswordConfirm('');
+
+      setTimeout(() => {
+        router.push('/login');
+      }, 2000);
     } catch (error) {
-      if (error instanceof Error) {
-        setError(error.message);
+      if (error instanceof AxiosError) {
+        setError(error);
+        setSnackbarOpen(true);
+      } else if (error instanceof Error) {
+        setError(error as AxiosError);
         setSnackbarOpen(true);
       }
     } finally {
-      setIsSubmitting(false);
+      setIsPasswordSubmitting(false);
     }
   };
 
   // 위키 생성 제출
   const handleWikiSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (isSubmitting) return;
 
-    setIsSubmitting(true);
-    setError('');
+    if (isWikiSubmitting) return;
+
+    setIsWikiSubmitting(true);
+    setError(null);
 
     try {
       // 프로필 생성 API 호출
@@ -100,11 +112,26 @@ function MyPage(): React.ReactElement {
       // 성공 시 위키 목록 페이지로 이동
       await router.push(`/wiki/${code}`);
     } catch (error) {
-      if (error instanceof Error) {
-        setError(error.message);
+      if (error instanceof AxiosError) {
+        const errorResponse = error.response?.data;
+        setError(error);
+        setSnackbarOpen(true);
+
+        // 이미 프로필이 존재하는 경우
+        if (errorResponse?.code) {
+          // 2초 후 해당 프로필로 이동
+          setTimeout(async () => {
+            await router.push(`/wiki/${errorResponse.code}`);
+          }, 2000);
+          return;
+        }
       }
+      // 기타 에러 처리
+      setError(error as AxiosError);
+      setSnackbarOpen(true);
     } finally {
-      setIsSubmitting(false);
+      // 제출 상태 해제
+      setIsWikiSubmitting(false);
     }
   };
 
@@ -133,12 +160,16 @@ function MyPage(): React.ReactElement {
   const inputContainerStyle = 'flex w-full flex-col gap-[8px]';
 
   return (
-    <div className="flex min-h-screen justify-center pt-[221px] mo:pt-[108px]">
-      <form onSubmit={handleSubmit} className="w-[400px] mo:w-[355px]">
-        <div className="flex w-full flex-col items-center gap-[32px]">
-          <h2 className="mb-[32px] text-center text-24sb text-gray-500">
-            계정설정
-          </h2>{' '}
+    <div className="flex min-h-screen justify-center pb-0 pt-[221px] mo:pb-[80px] mo:pt-[108px]">
+      <div className="flex w-full flex-col items-center gap-[32px]">
+        <h2 className="mb-[32px] text-center text-24sb text-gray-500">
+          계정설정
+        </h2>
+        {/* 비밀번호 변경 폼 */}
+        <form
+          onSubmit={handlePasswordSubmit}
+          className="flex w-[400px] flex-col items-center gap-[32px] mo:w-[335px]"
+        >
           <div className={inputSectionStyle}>
             <div className={inputContainerStyle}>
               <InputField
@@ -166,20 +197,25 @@ function MyPage(): React.ReactElement {
                 compareValue={newPassword}
                 placeholder="새 비밀번호 확인"
               />
-
               <Button
                 type="submit"
                 disabled={!isPasswordFormValid}
-                isLoading={Boolean(isSubmitting)}
+                isLoading={Boolean(isPasswordSubmitting)}
                 variant="primary"
                 size="small"
                 className="mt-[8px] self-end"
               >
                 변경하기
               </Button>
-            </div>{' '}
+            </div>
           </div>
-          <div className="w-full border-b border-gray-200"></div>
+        </form>
+        <div className="w-[400px] border-b border-gray-200 mo:w-[335px]"></div>
+        {/* 위키 생성 폼 */}
+        <form
+          onSubmit={handleWikiSubmit}
+          className="flex w-[400px] flex-col items-center gap-[32px] mo:w-[335px]"
+        >
           <div className={inputSectionStyle}>
             <div className={inputContainerStyle}>
               <InputField
@@ -200,29 +236,27 @@ function MyPage(): React.ReactElement {
               />
 
               <Button
-                type="button"
+                type="submit"
                 disabled={!isWikiFormValid}
-                isLoading={Boolean(isSubmitting)}
+                isLoading={Boolean(isWikiSubmitting)}
                 variant="primary"
                 size="small"
                 className="mt-[8px] self-end"
-                onClick={handleWikiSubmit}
               >
                 생성하기
               </Button>
             </div>
           </div>
-        </div>
-        {snackbarOpen && (
-          <SnackBar
-            severity="fail"
-            open={snackbarOpen}
-            onClose={() => setSnackbarOpen(false)}
-          >
-            {error}
-          </SnackBar>
-        )}
-      </form>
+        </form>
+      </div>
+      <SnackBar
+        open={snackbarOpen}
+        onClose={() => setSnackbarOpen(false)}
+        severity={error ? 'fail' : 'success'}
+        autoHideDuration={2000}
+      >
+        {error?.message || '비밀번호가 성공적으로 변경되었습니다.'}
+      </SnackBar>
     </div>
   );
 }


### PR DESCRIPTION
보안 질문 경고문구, mo: 계정설정 하단 여백

## 이슈 번호

close #235 

## 변경 사항 요약

- [x]  패스워드 변경 : 패스워드 변경 후 패스워드가 변경되었습니다 안내문구 필요함
- [x]  보안 질문 경고문구 : 보안 질문 답변이 설정돼있는 상태에서 다시 입력할때 경고문구가 뜨면 좋을 것 같습니다.
- [x]  [mo-아이폰15] 계정설정 하단 여백이 필요할것같음

## Doc

_`컴포넌트 인 경우 props를 입력해주세요`_

| **Props** | **Type** | **Description** |
| --------- | -------- | --------------- |
| `  `      | `  `     | 내용 입력       |
| `  `      | `  `     | 내용 입력       |

_`hooks 및 utils 인 경우 input,output을 입력해주세요`_

|            | **prams** | **Type** | **Description** |
| ---------- | --------- | -------- | --------------- |
| **input**  | `  `      | `  `     | 내용 입력       |
| **output** | `  `      | `  `     | 내용 입력       |

## 테스트 결과

_`베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.`_
_`컴포넌트의 경우 스크린샷을 포함해주세요.`_
