### PR TITLE
Feature/#245_QA-프로필컴포넌트관련

### DIFF
--- a/components/UserProfile.tsx
+++ b/components/UserProfile.tsx
@@ -54,14 +54,15 @@ function UserProfile({
     return (
       <p className="flex h-[18px] w-[200px] text-14 mo:w-[180px] mo:text-12 pc:gap-[20px]">
         <span className="flex-[1] text-gray-400">{label}</span>
-        <span className="flex-[2] text-gray-500">{data[field]}</span>
+        <span className="flex-[2] truncate text-gray-500">{data[field]}</span>
+        {/* truncate 클래스 - overflow:hidden, text-overflow:ellipsis, white-space:nowrap */}
       </p>
     );
   };
 
   return (
     // 메인 컨테이너
-    <div className="max-w-4xl rounded-custom bg-white shadow-custom dark:bg-gray-600 dark:shadow-custom-dark pc:h-[671px] pc:w-[320px] pc:p-7 tamo:w-full tamo:p-5">
+    <div className="max-w-4xl rounded-custom bg-background shadow-custom dark:shadow-custom-dark pc:h-auto pc:w-[320px] pc:p-7 tamo:w-full tamo:p-5">
       {/* 레이아웃 컨테이너: PC에서는 세로, 모바일/태블릿에서는 가로 배치 */}
       <div
         className={`flex ${isEditing ? 'flex-col' : 'flex-col mo:flex-row ta:flex-row pc:flex-col'}`}
@@ -156,7 +157,6 @@ function UserProfile({
                 {renderField('별명', 'nickname')}
                 {renderField('혈액형', 'bloodType')}
                 {renderField('국적', 'nationality')}
-                {renderField('가족관계', 'family')}
               </div>
             ) : (
               // 조회 모드: PC와 모바일/태블릿에서 다르게 표시


### PR DESCRIPTION
## 이슈 번호

close #245

## 변경 사항 요약

- 다크모드 적용
- 수정하기 들어갔을때 프로필 컴포넌트 안에 내용이 넘칩니다(일반상태일때도 간격다름)
- 인풋에 매우 긴 내용을 넣으면 다른 인풋내용과 겹쳐보입니다

## Doc

_`컴포넌트 인 경우 props를 입력해주세요`_

| **Props** | **Type** | **Description** |
| --------- | -------- | --------------- |
| `  `      | `  `     | 내용 입력       |
| `  `      | `  `     | 내용 입력       |

_`hooks 및 utils 인 경우 input,output을 입력해주세요`_

|            | **prams** | **Type** | **Description** |
| ---------- | --------- | -------- | --------------- |
| **input**  | `  `      | `  `     | 내용 입력       |
| **output** | `  `      | `  `     | 내용 입력       |

## 테스트 결과

_`베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.`_
_`컴포넌트의 경우 스크린샷을 포함해주세요.`_
