### PR TITLE
Feature/#253 qa 로그인버튼 비활성화 

### DIFF
--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -7,15 +7,13 @@ import InputField from '@/components/Input';
 import SnackBar from '@/components/SnackBar';
 import { AuthAPI } from '@/services/api/auth';
 
-function Login(): React.ReactElement {
+export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
-  const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'fail'>(
-    'success'
-  );
+  const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'fail'>('success');
   const [validFields, setValidFields] = useState({
     email: false,
     password: false,
@@ -39,11 +37,12 @@ function Login(): React.ReactElement {
 
   const isFormValid = validFields.email && validFields.password;
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (isSubmitting || !isFormValid) return;
 
     setIsSubmitting(true);
+
     try {
       const response = (await AuthAPI.signin({
         email,
@@ -55,10 +54,10 @@ function Login(): React.ReactElement {
       setSnackbarSeverity('success');
       setSnackbarOpen(true);
 
-      // 3초 후 메인 페이지로 이동
+      // 페이지 이동 전까지는 버튼을 비활성화 상태로 유지
       setTimeout(() => {
         router.push('/');
-      }, 3000);
+      }, 1000);
     } catch (error) {
       if (error instanceof Error) {
         setSnackbarMessage(error.message);
@@ -69,7 +68,7 @@ function Login(): React.ReactElement {
         setSnackbarSeverity('fail');
         setSnackbarOpen(true);
       }
-    } finally {
+      // 에러가 발생한 경우에만 isSubmitting을 false로 변경
       setIsSubmitting(false);
     }
   };
@@ -101,7 +100,7 @@ function Login(): React.ReactElement {
           />
           <Button
             type="submit"
-            disabled={!isFormValid}
+            disabled={!isFormValid || isSubmitting}
             isLoading={isSubmitting}
             variant="primary"
             className="mt-[6px] h-[45px] w-full"
@@ -130,5 +129,3 @@ function Login(): React.ReactElement {
     </div>
   );
 }
-
-export default Login;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -13,7 +13,9 @@ export default function Login() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
-  const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'fail'>('success');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'fail'>(
+    'success'
+  );
   const [validFields, setValidFields] = useState({
     email: false,
     password: false,

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -5,11 +5,13 @@ import Button from '@/components/Button';
 import InputField from '@/components/Input';
 import SnackBar from '@/components/SnackBar';
 import { useValidation } from '@/hooks/useValidation';
+import { useProfileContext } from '@/hooks/useProfileContext';
 import { AuthAPI } from '@/services/api/auth';
 import { ProfileAPI } from '@/services/api/profileAPI';
 import { AxiosError } from 'axios';
 
 function MyPage(): React.ReactElement {
+  const { profile } = useProfileContext();
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [newPasswordConfirm, setNewPasswordConfirm] = useState('');
@@ -210,44 +212,48 @@ function MyPage(): React.ReactElement {
             </div>
           </div>
         </form>
-        <div className="w-[400px] border-b border-gray-200 mo:w-[335px]"></div>
-        {/* 위키 생성 폼 */}
-        <form
-          onSubmit={handleWikiSubmit}
-          className="flex w-[400px] flex-col items-center gap-[32px] mo:w-[335px]"
-        >
-          <div className={inputSectionStyle}>
-            <div className={inputContainerStyle}>
-              <InputField
-                label="위키 생성하기"
-                type="text"
-                value={question}
-                width="100%"
-                onChange={handleQuestionChange}
-                placeholder="질문을 입력해 주세요"
-              />
-              <InputField
-                label=""
-                type="text"
-                value={answer}
-                width="100%"
-                onChange={handleAnswerChange}
-                placeholder="답을 입력해 주세요"
-              />
+        {/* 위키가 없을 때만 구분선과 위키 생성 폼 표시 */}
+        {!profile?.code && (
+          <>
+            <div className="w-[400px] border-b border-gray-200 mo:w-[335px]"></div>
+            <form
+              onSubmit={handleWikiSubmit}
+              className="flex w-[400px] flex-col items-center gap-[32px] mo:w-[335px]"
+            >
+              <div className={inputSectionStyle}>
+                <div className={inputContainerStyle}>
+                  <InputField
+                    label="위키 생성하기"
+                    type="text"
+                    value={question}
+                    width="100%"
+                    onChange={handleQuestionChange}
+                    placeholder="질문을 입력해 주세요"
+                  />
+                  <InputField
+                    label=""
+                    type="text"
+                    value={answer}
+                    width="100%"
+                    onChange={handleAnswerChange}
+                    placeholder="답을 입력해 주세요"
+                  />
 
-              <Button
-                type="submit"
-                disabled={!isWikiFormValid}
-                isLoading={Boolean(isWikiSubmitting)}
-                variant="primary"
-                size="small"
-                className="mt-[8px] self-end"
-              >
-                생성하기
-              </Button>
-            </div>
-          </div>
-        </form>
+                  <Button
+                    type="submit"
+                    disabled={!isWikiFormValid}
+                    isLoading={Boolean(isWikiSubmitting)}
+                    variant="primary"
+                    size="small"
+                    className="mt-[8px] self-end"
+                  >
+                    생성하기
+                  </Button>
+                </div>
+              </div>
+            </form>
+          </>
+        )}
       </div>
       <SnackBar
         open={snackbarOpen}

--- a/services/api/profileAPI.ts
+++ b/services/api/profileAPI.ts
@@ -40,6 +40,16 @@ export const ProfileAPI = {
       handleApiError(error);
     }
   },
+
+  // 현재 로그인한 사용자의 프로필 정보를 조회
+  getProfile: async () => {
+    try {
+      const res = await instance.get('/users/me');
+      return res.data.profile;
+    } catch (error) {
+      handleApiError(error);
+    }
+  },
 };
 
 // 위키 목록 페이지 요청 파라미터 타입


### PR DESCRIPTION
## 이슈 번호

close #253 

## 변경 사항 요약

- 로그인 완료시 로그인 버튼 비활성화 
- 마이페이지 진입했을때 위키가 생성되어있으면 위키 생성하기 안보이게 작업
@horororok 위 작업으로 ProfileAPI에 getProfile을 추가했습니다 확인부탁드립니다 

## Doc

_`컴포넌트 인 경우 props를 입력해주세요`_

| **Props** | **Type** | **Description** |
| --------- | -------- | --------------- |
| `  `      | `  `     | 내용 입력       |
| `  `      | `  `     | 내용 입력       |

_`hooks 및 utils 인 경우 input,output을 입력해주세요`_

|            | **prams** | **Type** | **Description** |
| ---------- | --------- | -------- | --------------- |
| **input**  | `  `      | `  `     | 내용 입력       |
| **output** | `  `      | `  `     | 내용 입력       |

## 테스트 결과

_`베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.`_
_`컴포넌트의 경우 스크린샷을 포함해주세요.`_
