### PR TITLE
Feature/#259 아이폰 16 버전 이상 사파리에서 is authenticated 상태 체크

### DIFF
--- a/components/Headers/Login.tsx
+++ b/components/Headers/Login.tsx
@@ -1,11 +1,12 @@
 import useOutsideClick from 'hooks/useOutsideClick';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { Profile } from 'types/profile';
 
 import Menu from '../Menu';
 import { useSnackbar } from 'context/SnackBarContext';
+import { ProfileContext } from 'context/ProfileContext';
 
 interface LoginProps {
   isMobile: boolean;
@@ -21,17 +22,21 @@ interface LoginProps {
  * @param isLoggedIn 로그인 여부 판별
  */
 
-export default function Login({ isMobile, isLoggedIn, profile }: LoginProps) {
+export default function Login({ isMobile }: LoginProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [profileMenu, setProfileMenu] = useState<string[]>([]);
   const { showSnackbar } = useSnackbar();
 
+  // ProfileContext에서 상태 가져오기
+  const profileContext = useContext(ProfileContext);
+  const { isAuthenticated, profile, setAccessToken } = profileContext || {};
   const profileImage = profile?.image ?? '/icon/icon-profile.svg';
+
   const router = useRouter();
   const loginMenuRef = useRef<HTMLDivElement>(null);
 
   const updateProfileMenu = useCallback(() => {
-    if (!isLoggedIn) {
+    if (!isAuthenticated) {
       if (isMobile) return ['로그인', '위키목록', '자유게시판'];
     } else if (isMobile) {
       return ['위키목록', '자유게시판', '알림', '마이페이지', '로그아웃'];
@@ -39,7 +44,7 @@ export default function Login({ isMobile, isLoggedIn, profile }: LoginProps) {
       return ['마이페이지', '로그아웃'];
     }
     return [];
-  }, [isLoggedIn, isMobile]); // 의존성 배열에 필요한 값만 포함
+  }, [isAuthenticated, isMobile]); // 의존성 배열에 필요한 값만 포함
 
   useEffect(() => {
     setProfileMenu(updateProfileMenu());
@@ -55,8 +60,11 @@ export default function Login({ isMobile, isLoggedIn, profile }: LoginProps) {
     } else if (option === '로그인') {
       await router.push('/login');
     } else if (option === '로그아웃') {
-      localStorage.removeItem('accessToken');
-      localStorage.removeItem('refreshToken');
+      // ProfileContext의 setAccessToken을 호출하여 로그아웃 처리
+      if (setAccessToken) {
+        setAccessToken(null); // accessToken 상태를 null로 설정
+      }
+      localStorage.removeItem('refreshToken'); // refreshToken 제거
       await router.push('/');
       showSnackbar('로그아웃 되었습니다.', 'fail');
     }
@@ -64,7 +72,7 @@ export default function Login({ isMobile, isLoggedIn, profile }: LoginProps) {
 
   useOutsideClick(loginMenuRef, () => setIsOpen(false));
 
-  return isLoggedIn ? (
+  return isAuthenticated ? (
     <div ref={loginMenuRef} className="flex">
       <div
         role="button"

--- a/context/ProfileContext.tsx
+++ b/context/ProfileContext.tsx
@@ -22,22 +22,27 @@ export const ProfileProvider: React.FC<{ children: ReactNode }> = ({
 
   //사용자 프로필 가져오기
   const getProfile = async () => {
+    console.log('[디버그] getProfile 함수 실행');
     const accessToken = localStorage.getItem('accessToken');
+    console.log('[디버그] accessToken:', accessToken);
     try {
       const res = await instance.get<UserProfileResponse>('/users/me', {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
       });
+      console.log('[디버그] /users/me 응답:', res.data);
 
       const profileData = res.data.profile;
 
       if (!profileData) {
+        console.log('[디버그] 프로필 데이터 없음.');
         setProfile(null);
         return;
       }
 
       const code = profileData.code;
+      console.log('[디버그] 프로필 코드:', code);
 
       if (!code) {
         setProfile(profileData);
@@ -45,9 +50,11 @@ export const ProfileProvider: React.FC<{ children: ReactNode }> = ({
       }
 
       const profileRes = await instance.get<Profile>(`/profiles/${code}`);
+      console.log('[디버그] /profiles/:code 응답:', profileRes.data);
 
       setProfile(profileRes.data);
     } catch {
+      console.log('[디버그] 프로필 로드 중 오류');
       setProfile(null);
     }
   };
@@ -64,6 +71,7 @@ export const ProfileProvider: React.FC<{ children: ReactNode }> = ({
           setProfile(null);
         });
       } else {
+        console.log('[디버그] 인증되지 않음');
         setIsAuthenticated(false);
         setProfile(null);
       }
@@ -73,6 +81,7 @@ export const ProfileProvider: React.FC<{ children: ReactNode }> = ({
     const originalRemoveItem = localStorage.removeItem.bind(localStorage);
 
     localStorage.setItem = (key: string, value: string) => {
+      console.log('[디버그] localStorage.setITem 호출');
       originalSetItem.call(localStorage, key, value);
       if (key === 'accessToken') {
         handleLocalStorageChange();
@@ -80,6 +89,7 @@ export const ProfileProvider: React.FC<{ children: ReactNode }> = ({
     };
 
     localStorage.removeItem = (key: string) => {
+      console.log('[디버그] localStorage.removeItem 호출');
       originalRemoveItem.call(localStorage, key);
       if (key === 'accessToken') {
         handleLocalStorageChange();
@@ -89,6 +99,7 @@ export const ProfileProvider: React.FC<{ children: ReactNode }> = ({
     handleLocalStorageChange();
 
     return () => {
+      console.log('[디버그] Effect 클린업 호출');
       localStorage.setItem = originalSetItem;
       localStorage.removeItem = originalRemoveItem;
     };

--- a/context/ProfileContext.tsx
+++ b/context/ProfileContext.tsx
@@ -1,6 +1,11 @@
-import React, { createContext, ReactNode, useEffect, useState } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import { Profile } from 'types/profile';
-
 import instance from '@/lib/axios-client';
 
 interface UserProfileResponse {
@@ -10,6 +15,7 @@ interface UserProfileResponse {
 interface ProfileContextType {
   isAuthenticated: boolean;
   profile: Profile | null;
+  setAccessToken: (token: string | null) => void; // 토큰 설정 함수
 }
 
 export const ProfileContext = createContext<ProfileContextType | null>(null);
@@ -19,94 +25,68 @@ export const ProfileProvider: React.FC<{ children: ReactNode }> = ({
 }) => {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
   const [profile, setProfile] = useState<Profile | null>(null);
+  const [accessToken, setAccessTokenState] = useState<string | null>(null);
 
-  //사용자 프로필 가져오기
-  const getProfile = async () => {
-    console.log('[디버그] getProfile 함수 실행');
-    const accessToken = localStorage.getItem('accessToken');
-    console.log('[디버그] accessToken:', accessToken);
+  // accessToken 상태를 업데이트하면서 localStorage와 동기화
+  const setAccessToken = (token: string | null) => {
+    if (token) {
+      localStorage.setItem('accessToken', token);
+    } else {
+      localStorage.removeItem('accessToken');
+    }
+    setAccessTokenState(token);
+  };
+
+  const getProfile = useCallback(async () => {
+    if (!accessToken) {
+      console.log('[디버그] 토큰 없음. 프로필을 불러올 수 없습니다.');
+      return;
+    }
+
     try {
       const res = await instance.get<UserProfileResponse>('/users/me', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
+        headers: { Authorization: `Bearer ${accessToken}` },
       });
-      console.log('[디버그] /users/me 응답:', res.data);
 
       const profileData = res.data.profile;
 
       if (!profileData) {
-        console.log('[디버그] 프로필 데이터 없음.');
         setProfile(null);
+        setIsAuthenticated(false);
         return;
       }
 
-      const code = profileData.code;
-      console.log('[디버그] 프로필 코드:', code);
-
-      if (!code) {
+      // 추가 정보 가져오기
+      if (profileData.code) {
+        const profileRes = await instance.get<Profile>(
+          `/profiles/${profileData.code}`
+        );
+        setProfile(profileRes.data);
+      } else {
         setProfile(profileData);
-        return;
       }
-
-      const profileRes = await instance.get<Profile>(`/profiles/${code}`);
-      console.log('[디버그] /profiles/:code 응답:', profileRes.data);
-
-      setProfile(profileRes.data);
+      setIsAuthenticated(true);
     } catch {
-      console.log('[디버그] 프로필 로드 중 오류');
+      setProfile(null);
+      setIsAuthenticated(false);
+    }
+  }, [accessToken]);
+
+  // accessToken 상태 변화 감지
+  useEffect(() => {
+    if (accessToken) {
+      setIsAuthenticated(true);
+      getProfile();
+    } else {
+      setIsAuthenticated(false);
       setProfile(null);
     }
-  };
-
-  //인증 상태 업데이트
-  useEffect(() => {
-    const handleLocalStorageChange = () => {
-      const accessToken = localStorage.getItem('accessToken');
-
-      if (accessToken !== null) {
-        setIsAuthenticated(true);
-        getProfile().catch(() => {
-          console.error('프로필을 불러오던 중 에러가 발생했습니다.');
-          setProfile(null);
-        });
-      } else {
-        console.log('[디버그] 인증되지 않음');
-        setIsAuthenticated(false);
-        setProfile(null);
-      }
-    };
-
-    const originalSetItem = localStorage.setItem.bind(localStorage);
-    const originalRemoveItem = localStorage.removeItem.bind(localStorage);
-
-    localStorage.setItem = (key: string, value: string) => {
-      console.log('[디버그] localStorage.setITem 호출');
-      originalSetItem.call(localStorage, key, value);
-      if (key === 'accessToken') {
-        handleLocalStorageChange();
-      }
-    };
-
-    localStorage.removeItem = (key: string) => {
-      console.log('[디버그] localStorage.removeItem 호출');
-      originalRemoveItem.call(localStorage, key);
-      if (key === 'accessToken') {
-        handleLocalStorageChange();
-      }
-    };
-
-    handleLocalStorageChange();
-
-    return () => {
-      console.log('[디버그] Effect 클린업 호출');
-      localStorage.setItem = originalSetItem;
-      localStorage.removeItem = originalRemoveItem;
-    };
-  }, []);
+  }, [accessToken, getProfile]); // accessToken이 변경될 때마다 실행
 
   return (
-    <ProfileContext.Provider value={{ isAuthenticated, profile }}>
+    <ProfileContext.Provider
+      value={{ isAuthenticated, profile, setAccessToken }}
+    >
       {children}
     </ProfileContext.Provider>
   );

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 
 import Button from '@/components/Button';
 import InputField from '@/components/Input';
 import { AuthAPI } from '@/services/api/auth';
 import { useSnackbar } from 'context/SnackBarContext';
+import { ProfileContext } from 'context/ProfileContext';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -15,6 +16,7 @@ export default function Login() {
     email: false,
     password: false,
   });
+  const profileContext = useContext(ProfileContext);
   const { showSnackbar } = useSnackbar();
   const router = useRouter();
 
@@ -38,22 +40,20 @@ export default function Login() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (isSubmitting || !isFormValid) return;
+    if (!profileContext) {
+      showSnackbar('ProfileContext를 찾을 수 없습니다.', 'fail');
+      return;
+    }
 
     setIsSubmitting(true);
 
     try {
-      const response = (await AuthAPI.signin({
-        email,
-        password,
-      })) as { accessToken: string };
+      await AuthAPI.signin({ email, password }, profileContext.setAccessToken);
 
-      localStorage.setItem('accessToken', response.accessToken);
+      router.push('/');
       showSnackbar('로그인이 완료되었습니다', 'success');
 
       // 페이지 이동 전까지는 버튼을 비활성화 상태로 유지
-      setTimeout(() => {
-        router.push('/');
-      }, 1000);
     } catch (error) {
       if (error instanceof Error) {
         showSnackbar(error.message, 'fail');

--- a/services/api/auth.ts
+++ b/services/api/auth.ts
@@ -2,14 +2,22 @@ import { AxiosError } from 'axios';
 
 import instance from '../../lib/axios-client';
 
+// AuthAPI 정의
 export const AuthAPI = {
-  signin: async (data: { email: string; password: string }) => {
+  signin: async (
+    data: { email: string; password: string },
+    setAccessToken: (token: string | null) => void // ProfileContext의 setAccessToken을 주입받음
+  ) => {
     try {
       const res = await instance.post('/auth/signIn', data);
 
       // 로그인 성공 시 토큰 저장
       const { accessToken, refreshToken } = res.data;
-      localStorage.setItem('accessToken', accessToken);
+
+      // setAccessToken을 통해 ProfileProvider 상태 업데이트
+      setAccessToken(accessToken);
+
+      // refreshToken은 여전히 localStorage에 직접 저장
       localStorage.setItem('refreshToken', refreshToken);
 
       return res.data;


### PR DESCRIPTION
## 이슈 번호

close #259 

## 변경 사항 요약

- 기존 localStorage.setItem 호출 방식을 react state 상태로 관리하는 것으로 변경하였습니다
- 로그인,로그아웃 로그인 관련 훅 로직도 state로 관리하는 방식으로 변경 되었습니다

## 원인

### ios 16 이하 버전에서는 정상 동작 했던 이유
- iOS 16 이전에는 localStorage.setItem이 동기적으로 작동하며, 데이터가 디스크에 즉시 저장되었습니다.
- React 애플리케이션에서 localStorage를 변경하면, 간접적인 감지 방법으로 UI 업데이트가 가능했습니다
- iOS 16 이전 Safari에서는 localStorage 사용에 대한 보안 정책이 비교적 느슨했습니다.
### ios 17 이상 버전에서 정상 동작 하지 않았던 이유
- iOS 16 이후 Safari에서 localStorage.setItem 호출 직후 React 애플리케이션이 localStorage를 다시 읽어올 때, 변경 사항이 반영되지 않을 가능성이 있습니다.
> iOS Safari가 localStorage를 내부적으로 **비동기적으로 처리**하기 시작했거나, 디스크 쓰기 전에 메모리 캐시를 사용하는 방식으로 변경되었을 수 있습니다.(ios 보안 정책 관련)
### 왜 16 이후 보안 강화를 했을까
- iOS 16 이상에서는 localStorage도 ITP의 범위에 포함되어, 추적 방지를 위해 데이터 접근을 제한하거나, Private Mode에서 데이터를 삭제하도록 변경되었습니다.
- localStorage의 동기적 처리는 브라우저 성능 및 보안 문제를 유발할 수 있습니다. **iOS Safari가 내부적으로 데이터를 비동기적으로 처리하도록 변경되었을 가능성이 있습니다.**
### 왜 setAccessToken으로 해결되었는가?
- **setAccessToken을 통해 accessToken을 React 상태로 관리하면, 데이터가 메모리 내에서 동기적으로 즉시 변경됩니다.**
- 브라우저의 비동기적인 localStorage 동작과 관계없이 상태 업데이트와 UI 렌더링이 즉시 이루어집니다.
- **React 상태(useState)는 변경 시 자동으로 의존하는 모든 컴포넌트를 다시 렌더링합니다.
이전에는 localStorage는 React 상태와 직접적으로 연동되지 않으므로, 수동으로 상태를 동기화해야 했습니다. setAccessToken을 사용함으로써 이 문제가 해결되었습니다.**
- setAccessToken 내부에서 localStorage.setItem을 호출하기 때문에 데이터는 여전히 저장됩니다. 그러나 React 상태로 accessToken을 관리하기 때문에, 브라우저의 localStorage 동작 문제와 상관없이 애플리케이션은 안정적으로 동작합니다.



## 테스트 결과

_`베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.`_
_`컴포넌트의 경우 스크린샷을 포함해주세요.`_

- [x] ios 사파리
- [x] 크롬
- [x] 카카오 웹뷰
- [x] 네이버 웹뷰
- [x] 크롬 웹 브라우저
- [x] 사파리 웹 브라우저

## 마치며
- 해당 이슈는 ios 보안 정책 변경으로 인한 문제 였음이 확인 되었고, 추후에도 유사한 이슈가 발생 될 경우 ios 보안 정책이 변경되지는않았는지 의심해볼만합니다. FE 개발자라면 기기별 보안 업데이트, 웹뷰 등 항상 최신의 정보를 알고있으면 좋을 듯 합니다.
- 프로젝트를 진행하면서 발생된 이슈 중 새롭게 얻어가는 정보인듯하니 해결에서 그치지않고 개인 블로그나 별도로 해당 이슈를 분석해보셨으면 합니다
